### PR TITLE
Specify a final comment period

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ The proposal champion can request feedback on their RFC at any point, either asy
 
 ## Stage 4: Ship it!
 
-An RFC is ready to be approved and finalized once it's Pull Request is ready for its final review. RFC approval can happen asynchronously, or in-person during one of our weekly community calls.
+An RFC is ready to be approved and finalized once it's Pull Request is ready for its final review. RFC approval can be happened through a "call for consensus". When a champion thinks the RFC is ready he can ask for a call for consensus.
 
-Final RFC approval happens by vote, following our existing [RFC Proposal](https://github.com/withastro/.github/blob/main/GOVERNANCE.md#voting-rfc-proposals) voting process.
+Some member of the core team will motion for a final comment period (FCP). This follows our existing [RFC Proposal](https://github.com/withastro/.github/blob/main/GOVERNANCE.md#voting-rfc-proposals) voting process. Once the final comment period has elapsed the RFC will be merged.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ The proposal champion can request feedback on their RFC at any point, either asy
 
 ## Stage 4: Ship it!
 
-An RFC is ready to be approved and finalized once it's Pull Request is ready for its final review. RFC approval can be happened through a "call for consensus". When a champion thinks the RFC is ready he can ask for a call for consensus.
+An RFC is ready to be approved and finalized once it's Pull Request is ready for its final review. When a champion thinks the RFC is ready he can ask for a call for consensus.
 
-Some member of the core team will motion for a final comment period (FCP). This follows our existing [RFC Proposal](https://github.com/withastro/.github/blob/main/GOVERNANCE.md#voting-rfc-proposals) voting process. Once the final comment period has elapsed the RFC will be merged.
+At this time, some member of the core team will motion for a final comment period (FCP). This follows our existing [RFC Proposal](https://github.com/withastro/.github/blob/main/GOVERNANCE.md#voting-rfc-proposals) voting process. Once the final comment period has elapsed the RFC will be merged if there are no objections.
 
 ---
 


### PR DESCRIPTION
Updates the language for how consensus works to match what we've been doing. Namely:

- Consensus is reached async during a final comment period.
- Rules here follow the governance voting rules.
- After the comment period the RFC is eligible for merging.