### PR TITLE
fix typo on import loadRenderers instead of laodRenderers

### DIFF
--- a/proposals/0048-container-api.md
+++ b/proposals/0048-container-api.md
@@ -145,7 +145,7 @@ a method called `getContainerRenderer` that will return the correct information 
 ```js
 import { getContainerRenderer as reactRenderer } from "@astrojs/react";
 import { getContainerRenderer as vueRenderer } from "@astrojs/vue";
-import { laodRenderers } from "astro:container";
+import { loadRenderers } from "astro:container";
 import { AstroContainer } from "astro/container";
 
 const renderers = loadRenderers([


### PR DESCRIPTION
I created this PR because I did not find other way to do the inline suggestion on existing rfc PR

Also I feel that the discussion was already made pior to my change that is just a fix for a typo in text
![image](https://github.com/user-attachments/assets/564433a1-713d-4aef-96f1-a6061043675b)

<!--
**Warning**
**This template is reserved for approved proposals and Astro maintainers only.**
You are probably looking to [**start a discussion**](https://github.com/withastro/roadmap/discussions/new)!

Community members who would like to propose an idea or feature should begin
by creating a GitHub Discussion. See the repo [`README.md`](https://github.com/withastro/roadmap#readme) for more info.
-->

# Summary

<!-- Short summary on what problem this RFC solves, and concise example usage of the feature -->
The rfc solves the container api

# Links

- [Rendered RFC](https://github.com/Scot3004/roadmap/blob/3dac369cdfc6e41dee2909b9920c2a85b3b76483/proposals/0048-container-api.md)

