### PR TITLE
Route Caching

### DIFF
--- a/proposals/0056-route-caching.md
+++ b/proposals/0056-route-caching.md
@@ -62,7 +62,7 @@ export const POST: APIRoute = ({ cache }) => {
 // src/pages/api/webhook.ts
 export const POST: APIRoute = ({ cache }) => {
   // Invalidate by tag
-  cache.invalidate({ tag: "product:laptop" });
+  cache.invalidate({ tag: "products" });
 
   return Response.json({ ok: true });
 };
@@ -101,6 +101,23 @@ export const POST: APIRoute = async ({ cache, request }) => {
 
   return Response.json({ ok: true });
 };
+```
+
+## Define cache in config
+
+```ts
+// astro.config.ts
+export default defineConfig({
+  adapter: node(),
+  cache: {
+    routes: {
+      "/": { maxAge: 0, swr: 60 },
+      "/blog/**": { maxAge: 300 },
+      "/products/**": { maxAge: 300, swr: 3600, tags: ["products"] },
+      "/api/**": { maxAge: 600 },
+    },
+  },
+});
 ```
 
 # Background & Motivation

--- a/proposals/0056-route-caching.md
+++ b/proposals/0056-route-caching.md
@@ -16,7 +16,7 @@
 - Reference Issues: https://github.com/withastro/roadmap/discussions/1131, https://github.com/withastro/roadmap/discussions/181
 - Implementation PR: <!-- leave empty -->
 - Stage 2 Issue: https://github.com/withastro/roadmap/issues/1140
-- Stage 3 PR: <!-- related roadmap PR, leave it empty if you don't have a PR yet -->
+- Stage 3 PR: https://github.com/withastro/roadmap/pull/1245
 
 # Summary
 

--- a/proposals/0056-route-caching.md
+++ b/proposals/0056-route-caching.md
@@ -166,10 +166,12 @@ Astro.cache.set(false);
 
 ```ts
 // astro.config.ts
+import { memoryCache } from "astro/config";
+
 export default defineConfig({
   adapter: node(),
   cache: {
-    provider: "@astrojs/node/cache",
+    provider: memoryCache(),
   },
   routeRules: {
     // Shortcut form (Nitro-style)
@@ -644,7 +646,7 @@ Astro will ship with built-in providers for common platforms:
 - `@astrojs/vercel/cache` - Vercel CDN (default for `@astrojs/vercel` adapter)
 - `@astrojs/netlify/cache` - Netlify CDN (default for `@astrojs/netlify` adapter)
 - `@astrojs/cloudflare/cache` - Cloudflare Workers response caching (default for `@astrojs/cloudflare` adapter)
-- `@astrojs/node/cache` - In-memory LRU cache (default for `@astrojs/node` adapter)
+- `astro/cache/memory` - Built-in in-memory LRU cache (available with any adapter)
 
 ### Provider Packages
 
@@ -1005,12 +1007,12 @@ export default defineConfig({
 
 ```ts
 // astro.config.ts
-import { cacheMemory } from "@astrojs/node/cache";
+import { memoryCache } from "astro/config";
 
 export default defineConfig({
   adapter: node(),
   cache: {
-    provider: cacheMemory({
+    provider: memoryCache({
       max: 1000, // Max cache entries (default: 1000)
     }),
   },
@@ -1224,20 +1226,20 @@ export default defineConfig({
 ### Scenario 5: Simple Node.js Deployment (Single Instance)
 
 **Setup:** Single Node.js server, no CDN
-**Provider:** `@astrojs/node/cache` (automatic default)
+**Provider:** `memoryCache()` from `astro/config` (automatic default)
 **Configuration:** Optional tuning of cache size
 **Behavior:** In-memory LRU cache, lost on restart
 
 ```ts
 // astro.config.ts
 import node from "@astrojs/node";
-import { cacheMemory } from "@astrojs/node/cache";
+import { memoryCache } from "astro/config";
 
 export default defineConfig({
   adapter: node(),
   // Optional: tune cache settings
   cache: {
-    provider: cacheMemory({
+    provider: memoryCache({
       max: 1000,
     }),
   },

--- a/proposals/0056-route-caching.md
+++ b/proposals/0056-route-caching.md
@@ -171,13 +171,15 @@ export default defineConfig({
   cache: {
     routes: {
       "/": { maxAge: 0, swr: 60 },
-      "/blog/**": { maxAge: 300 },
-      "/products/**": { maxAge: 300, swr: 3600, tags: ["products"] },
-      "/api/**": { maxAge: 600 },
+      "/blog/[...path]": { maxAge: 300 },
+      "/products/[...path]": { maxAge: 300, swr: 3600, tags: ["products"] },
+      "/api/[...path]": { maxAge: 600 },
     },
   },
 });
 ```
+
+Route patterns use the same `[param]` / `[...rest]` syntax as file-based routing and `redirects` in config. They follow the same priority rules: more segments win, static segments beat dynamic, single params beat rest params.
 
 # Background & Motivation
 
@@ -1020,18 +1022,22 @@ export default defineConfig({
     routes: {
       "/": { maxAge: 0, swr: 60 },
       "/blog/**": { maxAge: 300 },
-      "/products/**": { maxAge: 300, swr: 3600, tags: ["products"] },
-      "/api/**": { maxAge: 600 },
+      "/products/[...path]": { maxAge: 300, swr: 3600, tags: ["products"] },
+      "/api/[...path]": { maxAge: 600 },
     },
   },
 });
 ```
 
-**Pattern matching:**
+**Pattern syntax:**
+
+Route patterns use the same syntax as file-based routing and `redirects` in config:
 
 - Exact paths: `/about`
-- Wildcards: `/blog/*` (single segment), `/blog/**` (multiple segments)
-- Dynamic routes: `/products/[id]` (matches the file pattern)
+- Dynamic segments: `/products/[id]` (single segment)
+- Rest parameters: `/blog/[...slug]` (one or more segments)
+
+This reuses Astro's existing route parsing and priority infrastructure.
 
 **Precedence rules:**
 
@@ -1041,6 +1047,8 @@ export default defineConfig({
 4. Less specific route patterns
 5. No caching (default)
 
+Config route priority follows the same rules as file-based routing: more segments win, static segments beat dynamic, single params beat rest params.
+
 **No merging between config rules:** Each route pattern must be fully specified. A more specific pattern does not inherit settings from a less specific one.
 
 **Example with precedence:**
@@ -1048,9 +1056,9 @@ export default defineConfig({
 ```ts
 cache: {
   routes: {
-    '/blog/**': { maxAge: 300 },           // Matches all blog routes
-    '/blog/featured': { maxAge: 60 },      // More specific, wins for this route
-    '/blog/[slug]': { maxAge: 600 }        // Matches dynamic routes
+    '/blog/[...path]': { maxAge: 300 },    // Matches all blog routes
+    '/blog/featured': { maxAge: 60 },       // More specific, wins for this route
+    '/blog/[slug]': { maxAge: 600 }         // Matches single-segment dynamic routes
   }
 }
 ```

--- a/proposals/0056-route-caching.md
+++ b/proposals/0056-route-caching.md
@@ -1,0 +1,1133 @@
+<!--
+  Note: You are probably looking for `stage-1--discussion-template.md`!
+  This template is reserved for anyone championing an already-approved proposal.
+
+  Community members who would like to propose an idea or feature should begin
+  by creating a GitHub Discussion. See the repo README.md for more info.
+
+  To use this template: create a new, empty file in the repo under `proposals/${ID}.md`.
+  Replace `${ID}` with the official accepted proposal ID, found in the GitHub Issue
+  of the accepted proposal.
+-->
+
+**If you have feedback and the feature is released as experimental, please leave it on the Stage 3 PR. Otherwise, comment on the Stage 2 issue (links below).**
+
+- Start Date: 2025-10-15
+- Reference Issues: https://github.com/withastro/roadmap/discussions/1131, https://github.com/withastro/roadmap/discussions/181
+- Implementation PR: <!-- leave empty -->
+- Stage 2 Issue: https://github.com/withastro/roadmap/issues/1140
+- Stage 3 PR: <!-- related roadmap PR, leave it empty if you don't have a PR yet -->
+
+# Summary
+
+A platform-agnostic route caching API for Astro SSR pages that enables declarative cache control using web standards. The API provides a unified interface for caching server-rendered routes with support for time-to-live (TTL), stale-while-revalidate (SWR), tag-based invalidation, and automatic dependency tracking when used with live collections.
+
+# Example
+
+## Basic route caching
+
+```astro
+---
+// src/pages/products/[id].astro
+import { getEntry } from 'astro:content';
+
+const product = await getEntry('products', Astro.params.id);
+
+Astro.cache({
+  lastModified: product.updatedAt,
+  maxAge: 300,  // Cache for 5 minutes
+  swr: 3600,    // Stale-while-revalidate for 1 hour
+  tags: ['products', `product:${product.id}`]
+});
+---
+<h1>{product.data.name}</h1>
+<p>{product.data.description}</p>
+```
+
+## Cache invalidation by path
+
+```ts
+// src/pages/api/webhook.ts
+export const POST: APIRoute = ({ cache }) => {
+  // Invalidate by path
+  cache.invalidate({ path: "/products/laptop" });
+
+  return Response.json({ ok: true });
+};
+```
+
+## Cache invalidation by tag
+
+```ts
+// src/pages/api/webhook.ts
+export const POST: APIRoute = ({ cache }) => {
+  // Invalidate by tag
+  cache.invalidate({ tag: "product:laptop" });
+
+  return Response.json({ ok: true });
+};
+```
+
+## Integration with live collections
+
+```astro
+---
+// src/pages/products/[slug].astro
+import { getLiveEntry, render } from 'astro:content';
+
+const { entry, cacheHint } = await getLiveEntry('products', Astro.params.slug);
+
+// Apply cache hints from the live collection loader
+Astro.cache(cacheHint);
+
+const { Content } = await render(entry);
+---
+<h1>{entry.data.name}</h1>
+<Content />
+```
+
+## Automatic dependency tracking
+
+```ts
+// src/pages/api/revalidate.ts
+import { getLiveEntry } from "astro:content";
+
+export const POST: APIRoute = async ({ cache, request }) => {
+  const { id } = await request.json();
+  const { entry } = await getLiveEntry("products", id);
+
+  // Invalidate all pages that depend on this entry
+  cache.invalidate(entry);
+
+  return Response.json({ ok: true });
+};
+```
+
+# Background & Motivation
+
+Caching is essential for performant server-rendered applications, but current solutions have significant limitations:
+
+**Platform-specific implementations**: Most caching solutions (like ISR) are tightly coupled to specific hosting platforms. ISR was created for Next.js on Vercel and while other platforms have implemented versions of it, they're often limited or second-class implementations. This creates vendor lock-in and inconsistent behavior across deployments.
+
+**Manual header management**: Developers must manually set and coordinate multiple cache-related headers (`Cache-Control`, `CDN-Cache-Control`, `Cache-Tag`, `Last-Modified`, `ETag`), which is error-prone and platform-specific.
+
+**No standard invalidation**: Cache invalidation APIs vary wildly between platforms, making it difficult to write portable code that works everywhere.
+
+**Poor integration with content**: When using live collections or other data sources, developers must manually track dependencies and remember which cache tags to use for invalidation.
+
+[Live collections](https://github.com/withastro/roadmap/blob/feat/live-loaders/proposals/0055-live-content-loaders.md) introduced runtime data loading with cache hints, but applying those hints is awkward and requires manual header manipulation. We can provide a much better developer experience.
+
+# Goals
+
+- **Platform-agnostic API**: Single API that works consistently across all deployment targets
+- **Web standards-based**: Use standard HTTP headers where possible, with platform-specific optimizations when available
+- **Declarative cache control**: Simple, readable API for setting cache policies
+- **Tag-based invalidation**: Invalidate groups of related pages efficiently
+- **Path-based invalidation**: Invalidate specific routes by URL pattern
+- **Live collections integration**: Seamless integration with live collections by passing entries directly to `Astro.cache()`
+- **Automatic dependency tracking**: Invalidate all pages that depend on changed content entries
+- **Adapter abstraction**: Adapters provide platform-specific implementations with consistent behavior
+- **Pluggable cache drivers**: Users can configure cache drivers for different CDN providers (Fastly, Cloudflare, Akamai, etc.)
+- **Node.js support**: Functional in-memory caching for Node.js deployments
+
+# Non-Goals
+
+- **Strong consistency guarantees**: Cache invalidation follows eventual consistency model
+- **Distributed caching for Node.js**: Node adapter uses in-memory cache, unsuitable for multi-instance deployments without external cache
+- **Static/prerendered page caching**: This is for on-demand SSR routes only; static and prerendered routes are already cached by default and don't need route-level cache control
+- **Browser caching**: This focuses on CDN and server-side caching, not browser caching. Only `Last-Modified` and `ETag` headers are sent to browsers for conditional requests
+- **Response body caching API**: This focuses on HTTP-level caching, not application-level data caching
+- **Building or maintaining all CDN-specific drivers**: We'll provide a driver interface and some select implementations, but rely on community or CDN vendors to maintain platform-specific implementations
+
+# Detailed Design
+
+## API
+
+### `Astro.cache(options | cacheHint)`
+
+Called within a route to declare caching behavior. This function sets the appropriate headers for the current adapter.
+
+**Important:** This API only works in on-demand SSR routes. Static and prerendered routes are already cached and don't support route-level cache control.
+
+**With cache options:**
+
+```astro
+---
+Astro.cache({
+  maxAge: 300,
+  swr: 3600,
+  tags: ['products', 'product:123'],
+  lastModified: new Date('2025-01-15')
+});
+---
+```
+
+**Options:**
+
+- `maxAge: number` - Time in seconds the response should be considered fresh
+- `swr?: number` - Additional seconds to serve stale content while revalidating in background
+- `tags?: string[]` - Cache tags for group invalidation
+- `lastModified?: Date` - Last modified time for conditional requests
+- `etag?: string` - ETag value for conditional requests
+
+**With cache hints from live collections:**
+
+When using live collections, pass the `cacheHint` object returned by `getLiveEntry()` or `getLiveCollection()`:
+
+```astro
+---
+const { entry, cacheHint } = await getLiveEntry('products', Astro.params.id);
+
+// Apply cache hints from the live collection loader
+Astro.cache(cacheHint);
+---
+```
+
+The `cacheHint` object contains pre-configured cache metadata including tags, lastModified, and other cache-related properties specific to that content entry.
+
+### `cache.invalidate(options | entry)`
+
+Available in API routes and server endpoints via the `cache` object on the API context. Invalidates cached responses.
+
+**Invalidate by path:**
+
+```ts
+cache.invalidate({ path: "/products/laptop" });
+cache.invalidate({ path: "/blog/*" }); // Pattern matching
+```
+
+**Invalidate by tag:**
+
+```ts
+cache.invalidate({ tag: "products" });
+cache.invalidate({ tags: ["products", "featured"] });
+```
+
+**Invalidate by entry:**
+
+```ts
+const entry = await getLiveEntry("products", id);
+cache.invalidate(entry); // Invalidates all routes that used this entry with Astro.cache()
+```
+
+## Cache Provider Interface
+
+Cache providers implement platform-specific caching logic while maintaining a consistent developer experience. Similar to how sessions use pluggable storage drivers, route caching uses pluggable cache providers.
+
+### Provider Interface
+
+```ts
+interface CacheProvider {
+  name: string;
+
+  /**
+   * Optional: Map cache options to platform-specific headers
+   * If not provided, defaults to CDN-Cache-Control + Cache-Tag headers
+   */
+  setHeaders?(options: CacheOptions): Headers;
+
+  /**
+   * Optional: Middleware-style hook for runtime caching
+   * Used by runtime providers (node-memory, cloudflare-workers)
+   *
+   * Follows the same API as Astro middleware:
+   * - Check cache using context.request
+   * - If cache hit, return cached response (don't call next())
+   * - If cache miss, call next() to get response from route
+   * - Read cache headers from response to determine caching behavior
+   * - Store response in cache
+   * - Return response
+   */
+  onRequest?(
+    context: MiddlewareContext,
+    next: () => Promise<Response>
+  ): Promise<Response>;
+
+  /**
+   * Invalidate cached content
+   */
+  invalidate(options: InvalidateOptions): Promise<void>;
+}
+
+interface CacheOptions {
+  maxAge?: number;
+  swr?: number;
+  tags?: string[];
+  lastModified?: Date;
+  etag?: string;
+}
+
+interface InvalidateOptions {
+  path?: string;
+  tag?: string;
+  tags?: string[];
+}
+```
+
+### Provider Types
+
+There are two fundamental types of cache providers:
+
+**Header-based Providers** (Vercel, Netlify, Fastly, Cloudflare CDN, Akamai):
+
+- Implement `setHeaders()` to generate platform-specific cache headers
+- Implement `invalidate()` to call platform purge APIs
+- Do NOT implement `onRequest()` - external CDN handles actual caching
+- Cache happens outside the application runtime
+
+**Runtime Providers** (Node memory, Cloudflare Workers):
+
+- Implement `onRequest()` middleware to intercept requests and handle caching
+- Implement `invalidate()` to delete from cache store
+- May optionally implement `setHeaders()` for platform-specific header formats
+- Read cache headers (CDN-Cache-Control, Cache-Tag) from responses to determine caching behavior
+- Cache happens within the application runtime (memory, KV, Cache API, etc.)
+
+**Runtime provider middleware flow:**
+
+```ts
+async onRequest(context, next) {
+  // 1. Check cache using context.request. Assume this.cache is a simple key-value store.
+  const cached = await this.cache.get(context.url.pathname);
+  if (cached && !isExpired(cached)) {
+    return cached.response;
+  }
+
+  // 2. Call next() to get response from route
+  const response = await next();
+
+  // 3. Read cache headers from response
+  const cacheControl = response.headers.get('CDN-Cache-Control');
+  const cacheTags = response.headers.get('Cache-Tag');
+
+  // 4. Store response in cache based on headers
+  if (cacheControl) {
+    await this.cache.set(context.url.pathname, {
+      response: response.clone(),
+      tags: cacheTags?.split(', '),
+      // ... parse maxAge, swr from cacheControl
+    });
+  }
+
+  // 5. Return response
+  return response;
+}
+```
+
+**Unified Flow:**
+
+1. `Astro.cache()` or config rules generate cache options
+2. Options converted to headers (via `setHeaders()` or default implementation)
+3. Headers set on response
+4. **Runtime providers** read headers in `onRequest()` middleware to determine caching behavior
+5. **Header-based providers** pass headers through to external CDN
+
+This design ensures consistent behavior: runtime providers honour the same cache headers that external CDNs use.
+
+### Example Runtime Provider Implementation
+
+Here's a complete example of a Node memory provider implementation:
+
+```ts
+import { LRUCache } from "lru-cache";
+
+class NodeMemoryProvider implements CacheProvider {
+  name = "node-memory";
+  private cache: LRUCache<string, CachedEntry>;
+
+  constructor(options?: { max?: number; ttl?: number }) {
+    this.cache = new LRUCache({
+      max: options?.max ?? 500,
+      ttl: options?.ttl ?? 1000 * 60 * 5, // 5 minutes default
+      allowStale: true,
+      updateAgeOnGet: true,
+    });
+  }
+
+  async onRequest(
+    context: CacheMiddlewareContext,
+    next: () => Promise<Response>
+  ): Promise<Response> {
+    // In real implementation, normalise the URL params etc
+    const cacheKey = context.url.pathname + context.url.search;
+
+    // Check cache
+    const cached = this.cache.get(cacheKey);
+    if (cached && !this.isExpired(cached)) {
+      return cached.response.clone();
+    }
+
+    // Get response from route
+    const response = await next();
+
+    // Parse cache headers
+    const cacheControl = response.headers.get("CDN-Cache-Control");
+    if (cacheControl) {
+      const { maxAge, swr } = this.parseCacheControl(cacheControl);
+      const tags = response.headers.get("Cache-Tag")?.split(", ") ?? [];
+
+      // Store in cache
+      this.cache.set(cacheKey, {
+        response: response.clone(),
+        tags,
+        maxAge,
+        swr,
+        timestamp: Date.now(),
+      });
+    }
+
+    return response;
+  }
+
+  async invalidate(options: InvalidateOptions): Promise<void> {
+    // Naive implementation iterates all keys
+
+    if (options.path) {
+      // Invalidate by path (with wildcard support)
+      const pattern = new URLPattern(options.path);
+      for (const key of this.cache.keys()) {
+        if (pattern.test(key)) {
+          this.cache.delete(key);
+        }
+      }
+    }
+
+    if (options.tag || options.tags) {
+      const tags = options.tags ?? [options.tag!];
+      // Invalidate by tag
+      for (const [key, value] of this.cache.entries()) {
+        if (value.tags.some((tag) => tags.includes(tag))) {
+          this.cache.delete(key);
+        }
+      }
+    }
+  }
+}
+```
+
+This example demonstrates:
+
+- Middleware-style `onRequest()` that checks cache before calling `next()`
+- Reading cache headers from the response to determine caching behavior
+- Storing responses with metadata (tags, TTL, timestamp)
+- Invalidation by both path patterns and cache tags
+- Proper response cloning to avoid consuming the stream
+
+### Default Header Generation
+
+If a provider doesn't implement `setHeaders()`, Astro uses a default implementation:
+
+```ts
+// Default header generation
+function defaultSetHeaders(options: CacheOptions): Headers {
+  const headers = new Headers();
+
+  // Build Cache-Control value
+  const directives = ["public"];
+  if (options.maxAge !== undefined) {
+    directives.push(`max-age=${options.maxAge}`);
+  }
+  if (options.swr !== undefined) {
+    directives.push(`stale-while-revalidate=${options.swr}`);
+  }
+
+  headers.set("CDN-Cache-Control", directives.join(", "));
+
+  if (options.tags?.length) {
+    headers.set("Cache-Tag", options.tags.join(", "));
+  }
+
+  if (options.lastModified) {
+    headers.set("Last-Modified", options.lastModified.toUTCString());
+  }
+
+  if (options.etag) {
+    headers.set("ETag", options.etag);
+  }
+
+  return headers;
+}
+```
+
+**Browser vs CDN caching:**
+
+This API focuses on CDN and server-side caching, not browser caching. The `CDN-Cache-Control` and `Cache-Tag` headers are stripped before reaching the browser. Only `Last-Modified` and `ETag` headers are sent to browsers to enable conditional requests (304 Not Modified responses).
+
+Providers can override this to use platform-specific headers. For example:
+
+- Fastly overrides to use `Surrogate-Control` instead of `CDN-Cache-Control`, and `Surrogate-Key` instead of `Cache-Tag`
+- Netlify uses `Netlify-CDN-Cache-Control` with additional directives and Vary header support
+
+### Built-in Providers
+
+Astro will ship with built-in providers for common platforms:
+
+- `vercel` - Vercel CDN (default for `@astrojs/vercel` adapter)
+- `netlify` - Netlify CDN (default for `@astrojs/netlify` adapter)
+- `cloudflare-workers` - Cloudflare Workers Cache API (default for `@astrojs/cloudflare` adapter)
+- `node-memory` - In-memory LRU cache (default for `@astrojs/node` adapter)
+
+### Driver Packages
+
+Driver packages can be distributed as npm packages:
+
+- `@astrojs/cache-cloudflare-cdn` - Cloudflare as proxy in front of other origins
+- `@astrojs/cache-fastly` - Fastly CDN support
+- `@astrojs/cache-akamai` - Akamai edge caching
+- Custom providers for other CDNs or caching solutions
+- Custom runtime providers using external stores (Redis, Memcached, etc.)
+
+Driver packages export a cache provider that can be referenced by package name in the config and dynamically imported at runtime.
+
+## Adapter Abstraction
+
+Adapters provide platform-specific caching implementations while maintaining a consistent API. This follows the same pattern as the [Sessions API](https://docs.astro.build/en/guides/sessions/), where adapters can provide defaults and customize behavior.
+
+### Header Mapping
+
+Each cache provider maps `Astro.cache()` options to platform-specific headers or APIs:
+
+**Vercel Provider (`vercel`):**
+
+```
+maxAge + swr → CDN-Cache-Control: public, max-age=300, stale-while-revalidate=3600
+tags → Cache-Tag: products, product:123
+lastModified → Last-Modified: Thu, 15 Jan 2025 00:00:00 GMT
+```
+
+**Netlify Provider (`netlify`):**
+
+```
+maxAge + swr → Netlify-CDN-Cache-Control: public, max-age=300, stale-while-revalidate=3600, durable
+tags → Netlify-Cache-Tag: products, product:123
+lastModified → Last-Modified: Thu, 15 Jan 2025 00:00:00 GMT
+```
+
+**Cloudflare Workers Provider (`cloudflare-workers`):**
+Uses the Workers Cache API directly when SSR runs in a Cloudflare Worker:
+
+```ts
+const cache = caches.default;
+const cacheKey = new Request(url, request);
+await cache.put(cacheKey, response.clone());
+```
+
+Tags are stored in KV for invalidation mapping. Invalidation looks up tag mappings in KV, then deletes from cache.
+
+**Cloudflare CDN Provider (`cloudflare-cdn`):**
+For use when Cloudflare acts as a CDN/proxy in front of another origin (like Node.js):
+
+```
+maxAge + swr → Cache-Control: public, s-maxage=300, stale-while-revalidate=3600
+tags → Cache-Tag: products, product:123
+lastModified → Last-Modified: Thu, 15 Jan 2025 00:00:00 GMT
+```
+
+Invalidation via Cloudflare's purge API requires zone ID and API token.
+
+**Fastly Provider (`fastly`):**
+
+```
+maxAge + swr → Surrogate-Control: max-age=300, stale-while-revalidate=3600
+tags → Surrogate-Key: products product:123
+lastModified → Last-Modified: Thu, 15 Jan 2025 00:00:00 GMT
+```
+
+Note: Fastly uses `Surrogate-Control` and `Surrogate-Key` headers (proprietary Fastly headers). While Fastly co-authored RFC 9213 (CDN-Cache-Control), their documentation recommends using Surrogate-Control. Individual keys limited to 1024 bytes, total header limited to 16,384 bytes. Purge typically happens in ~1ms via batch API.
+
+**Akamai Provider (`akamai`):**
+
+```
+maxAge + swr → CDN-Cache-Control: public, max-age=300, stale-while-revalidate=3600
+tags → Edge-Cache-Tag: products,product:123
+lastModified → Last-Modified: Thu, 15 Jan 2025 00:00:00 GMT
+```
+
+Note: Akamai supports the standardized `CDN-Cache-Control` header (RFC 9213) for Targeted Cache Control. Individual tags limited to 128 characters, total header limited to 8192 bytes. Tags are case-sensitive.
+
+**Node Memory Provider (`node-memory`):**
+
+In-memory LRU cache using `lru-cache` library with stale-while-revalidate support. As a runtime provider, it reads the `CDN-Cache-Control` and `Cache-Tag` headers set by the default header generation to determine caching behavior.
+
+### Invalidation Implementation
+
+Each cache provider implements invalidation differently:
+
+**Vercel Provider:**
+
+```ts
+// Call Vercel's edge cache invalidation API
+// https://vercel.com/docs/rest-api/reference/endpoints/edge-cache/invalidate-by-tag
+await fetch(`https://api.vercel.com/v1/edge-cache/invalidate-by-tags`, {
+  method: "POST",
+  headers: {
+    Authorization: `Bearer ${process.env.VERCEL_TOKEN}`,
+    "Content-Type": "application/json",
+  },
+  body: JSON.stringify({
+    tags: [tag],
+    target: "production",
+  }),
+});
+```
+
+**Netlify Provider:**
+
+```ts
+// Use Netlify's purgeCache helper
+// https://docs.netlify.com/build/caching/caching-overview/#purge-by-cache-tag
+import { purgeCache } from "@netlify/functions";
+
+await purgeCache({ tags: [tag] });
+```
+
+**Cloudflare Workers Provider:**
+
+```ts
+// Look up tag mappings in KV
+const routes = await env.CACHE_TAGS.get(`tag:${tag}`, { type: "json" });
+// Delete each route from cache
+for (const route of routes) {
+  await caches.default.delete(route);
+}
+```
+
+**Cloudflare CDN Provider:**
+
+```ts
+// Call Cloudflare's purge API
+// https://developers.cloudflare.com/api/resources/cache/methods/purge/
+await fetch(
+  `https://api.cloudflare.com/client/v4/zones/${zoneId}/purge_cache`,
+  {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${process.env.CF_TOKEN}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ tags: [tag] }),
+  }
+);
+```
+
+**Node Memory Provider:**
+
+```ts
+// Clear from in-memory cache
+cache.delete(key);
+// Or clear all entries with a tag
+for (const [key, value] of cache.entries()) {
+  if (value.tags?.includes(tag)) {
+    cache.delete(key);
+  }
+}
+```
+
+### Adapter Integration
+
+Adapters provide default cache drivers via the integration API, similar to how they provide session drivers. Users can override the default driver in their config.
+
+**Driver Loading:**
+
+Similar to sessions, cache drivers are loaded at runtime. Built-in drivers (`vercel`, `netlify`, `cloudflare-workers`, `node-memory`) are available by name. Driver packages are referenced by their package name and dynamically imported.
+
+**Adapter providing a default:**
+
+```ts
+// Example: @astrojs/vercel adapter
+export function vercel() {
+  return {
+    name: "@astrojs/vercel",
+    hooks: {
+      "astro:config:done": ({ setAdapter }) => {
+        setAdapter({
+          name: "@astrojs/vercel",
+          // ...other adapter properties
+          // Provide default cache driver
+          cache: {
+            driver: "vercel", // Built-in Vercel driver
+          },
+        });
+      },
+    },
+  };
+}
+```
+
+**User overriding the default with a driver package:**
+
+```ts
+// astro.config.ts
+export default defineConfig({
+  adapter: node(),
+  cache: {
+    // Override Node's default in-memory cache with Fastly
+    driver: "@astrojs/cache-fastly",
+    options: {
+      serviceId: process.env.FASTLY_SERVICE_ID,
+      token: process.env.FASTLY_TOKEN,
+    },
+  },
+});
+```
+
+**Driver packages:**
+
+Driver packages like `@astrojs/cache-fastly` export a cache provider implementation:
+
+```ts
+// @astrojs/cache-fastly/index.ts
+export default function fastlyProvider(options) {
+  return {
+    name: "fastly",
+    setHeaders(cacheOptions) {
+      /* ... */
+    },
+    async invalidate(options) {
+      /* ... */
+    },
+  };
+}
+```
+
+Astro dynamically imports the package when referenced by name in the config.
+
+**Precedence:**
+
+1. User-configured `cache.driver` in `astro.config.ts` (highest priority)
+2. Adapter-provided default via `setAdapter()`
+3. Generic `node-memory` driver (fallback)
+
+## Dependency Tracking
+
+Dependency tracking is implemented using cache tags rather than in-memory state. When you pass a `cacheHint` to `Astro.cache()`, it contains pre-configured cache tags based on the content entry.
+
+**Automatic tag generation:**
+
+```astro
+---
+const { entry, cacheHint } = await getLiveEntry('products', 'laptop');
+
+// cacheHint contains cache tags:
+// - 'collection:products'
+// - 'entry:products:laptop'
+Astro.cache(cacheHint);
+---
+```
+
+**Equivalent to:**
+
+```astro
+---
+Astro.cache({
+  tags: [
+    'collection:products',
+    'entry:products:laptop'
+  ],
+  lastModified: entry.data.updatedAt,
+  // ... other metadata from cacheHint
+});
+---
+```
+
+**Invalidating by entry:**
+When `cache.invalidate(entry)` is called, it invalidates the appropriate cache tags:
+
+```ts
+// src/pages/api/webhook.ts
+import { getLiveEntry } from "astro:content";
+
+export const POST: APIRoute = async ({ cache, request }) => {
+  const { id } = await request.json();
+
+  const entry = await getLiveEntry("products", id);
+
+  // This invalidates the tag 'entry:products:123'
+  // All routes that used this entry will be purged
+  cache.invalidate(entry);
+
+  return Response.json({ ok: true });
+};
+```
+
+**Behind the scenes:**
+
+```ts
+cache.invalidate(entry);
+// Translates to:
+cache.invalidate({ tags: entry.cacheHint.tags });
+```
+
+tags
+
+## Configuration
+
+Route caching works automatically when using an adapter that supports it. Adapters provide sensible defaults, but users can customize or override them.
+
+### Cache Provider Configuration
+
+**Using adapter defaults (no configuration needed):**
+
+```ts
+// astro.config.ts
+export default defineConfig({
+  adapter: vercel(), // Uses 'vercel' provider by default
+});
+```
+
+**Overriding with a driver package:**
+
+```ts
+// astro.config.ts
+export default defineConfig({
+  adapter: node(),
+  cache: {
+    // Node app behind Cloudflare CDN
+    driver: "@astrojs/cache-cloudflare-cdn",
+    options: {
+      zoneId: process.env.CF_ZONE_ID,
+      token: process.env.CF_TOKEN,
+    },
+  },
+});
+```
+
+**Using Fastly with Node:**
+
+```ts
+// astro.config.ts
+export default defineConfig({
+  adapter: node(),
+  cache: {
+    driver: "@astrojs/cache-fastly",
+    options: {
+      serviceId: process.env.FASTLY_SERVICE_ID,
+      token: process.env.FASTLY_TOKEN,
+    },
+  },
+});
+```
+
+**Configuring the built-in Node memory cache:**
+
+```ts
+// astro.config.ts
+export default defineConfig({
+  adapter: node(),
+  cache: {
+    driver: "node-memory", // Explicitly use default
+    options: {
+      max: 1000, // Max cache entries
+      ttl: 300000, // Default TTL in ms
+    },
+  },
+});
+```
+
+### Route-Level Cache Rules
+
+You can also declare cache rules for routes in your config. These act as defaults that can be overridden by `Astro.cache()` calls within routes.
+
+**Basic route patterns:**
+
+```ts
+// astro.config.ts
+export default defineConfig({
+  adapter: vercel(),
+  cache: {
+    routes: {
+      "/": { maxAge: 0, swr: 60 },
+      "/blog/**": { maxAge: 300 },
+      "/products/**": { maxAge: 300, swr: 3600, tags: ["products"] },
+      "/api/**": { maxAge: 600 },
+    },
+  },
+});
+```
+
+**Pattern matching:**
+
+- Exact paths: `/about`
+- Wildcards: `/blog/*` (single segment), `/blog/**` (multiple segments)
+- Dynamic routes: `/products/[id]` (matches the file pattern)
+
+**Precedence rules:**
+
+1. `Astro.cache()` called in the route (highest priority)
+2. Most specific matching route pattern in config
+3. Less specific route patterns
+4. No caching (default)
+
+**Example with precedence:**
+
+```ts
+cache: {
+  routes: {
+    '/blog/**': { maxAge: 300 },           // Matches all blog routes
+    '/blog/featured': { maxAge: 60 },      // More specific, wins for this route
+    '/blog/[slug]': { maxAge: 600 }        // Matches dynamic routes
+  }
+}
+```
+
+```astro
+---
+// src/pages/blog/[slug].astro
+// This page uses maxAge: 600 from config by default
+// But can override it:
+Astro.cache({ maxAge: 900 }); // This wins
+---
+```
+
+**Benefits of config-based rules:**
+
+- Set defaults for entire route patterns
+- No need to add `Astro.cache()` to every page
+- Centralized cache policy
+- Useful for API routes and pages that don't use live collections
+
+## Node.js Implementation Details
+
+The Node adapter maintains an in-memory LRU cache using the `lru-cache` library, which provides:
+
+- Automatic eviction of least-recently-used entries
+- Built-in stale-while-revalidate support via `fetchMethod`
+- TTL management
+- Size limits to prevent memory issues
+
+**Important limitations:**
+
+- Cache is per-process, not shared across multiple Node instances
+- Cache is lost on process restart
+- Not suitable for horizontally scaled deployments without external cache
+
+**For distributed Node deployments**, users should:
+
+- Use a CDN in front of Node servers (recommended)
+- Implement a custom cache driver using Redis, Memcached, or another distributed cache
+- Use a platform with built-in edge caching (Vercel, Netlify, Cloudflare)
+
+## Real-World Deployment Scenarios
+
+### Scenario 1: Vercel Deployment
+
+**Setup:** Deploy directly to Vercel using `@astrojs/vercel` adapter
+**Provider:** `vercel` (automatic default)
+**Configuration:** None required
+**Behavior:** Uses Vercel's CDN-Cache-Control and Cache-Tag headers, invalidation via Vercel API
+
+```ts
+// astro.config.ts
+export default defineConfig({
+  adapter: vercel(), // That's it!
+});
+```
+
+### Scenario 2: Node.js Behind Cloudflare CDN
+
+**Setup:** Self-hosted Node.js server with Cloudflare as CDN/proxy
+**Driver:** `@astrojs/cache-cloudflare-cdn` (user configured, driver package)
+**Configuration:** Requires Cloudflare zone ID and API token
+**Behavior:** Sets Cache-Tag headers, invalidation via Cloudflare purge API
+
+```ts
+// astro.config.ts
+export default defineConfig({
+  adapter: node(),
+  cache: {
+    driver: "@astrojs/cache-cloudflare-cdn",
+    options: {
+      zoneId: process.env.CF_ZONE_ID,
+      token: process.env.CF_TOKEN,
+    },
+  },
+});
+```
+
+### Scenario 3: Cloudflare Workers
+
+**Setup:** SSR running directly in Cloudflare Workers
+**Driver:** `cloudflare-workers` (automatic default)
+**Configuration:** None required, uses KV for tag mapping
+**Behavior:** Uses Workers Cache API directly, stores tag mappings in KV
+
+```ts
+// astro.config.ts
+export default defineConfig({
+  adapter: cloudflare(), // Automatically uses cloudflare-workers driver
+});
+```
+
+### Scenario 4: Node.js Behind Fastly
+
+**Setup:** Self-hosted Node.js with Fastly CDN
+**Driver:** `@astrojs/cache-fastly` (user configured, driver package)
+**Configuration:** Requires Fastly service ID and API token
+**Behavior:** Sets Surrogate-Key headers, invalidation via Fastly batch purge API (~1ms)
+
+```ts
+// astro.config.ts
+export default defineConfig({
+  adapter: node(),
+  cache: {
+    driver: "@astrojs/cache-fastly",
+    options: {
+      serviceId: process.env.FASTLY_SERVICE_ID,
+      token: process.env.FASTLY_TOKEN,
+    },
+  },
+});
+```
+
+### Scenario 5: Simple Node.js Deployment (Single Instance)
+
+**Setup:** Single Node.js server, no CDN
+**Driver:** `node-memory` (automatic default)
+**Configuration:** Optional tuning of cache size
+**Behavior:** In-memory LRU cache, lost on restart
+
+```ts
+// astro.config.ts
+import node from "@astrojs/node";
+
+export default defineConfig({
+  adapter: node(),
+  // Optional: tune cache settings
+  cache: {
+    options: {
+      max: 1000,
+      ttl: 300000,
+    },
+  },
+});
+```
+
+**Limitation:** Not suitable for multi-instance deployments (cache not shared across instances).
+
+# Testing Strategy
+
+## Unit Tests
+
+- Test `Astro.cache()` API with mock providers
+- Test cache option validation and defaults
+- Test automatic tag generation when passing entries
+- Test entry cache hint extraction
+
+## Integration Tests
+
+- Test each adapter's header generation
+- Verify correct headers are set for each platform
+- Test tag parsing and formatting
+
+## E2E Tests
+
+- Test actual cache behavior on each platform (Vercel, Netlify, Cloudflare, Node)
+- Test invalidation via API routes
+- Test stale-while-revalidate behavior
+- Test dependency tracking with live collections
+- Test Node adapter LRU cache eviction and TTL
+
+## Adapter Tests
+
+Individual adapters should include tests for:
+
+- Platform-specific header mapping
+- Invalidation API integration
+- Error handling when API tokens are missing
+
+# Drawbacks
+
+- **Adapter complexity**: Adapters must implement platform-specific caching logic, increasing maintenance burden
+- **Node.js limitations**: In-memory cache doesn't work for distributed deployments, requiring external solutions or CDN
+- **Eventual consistency**: Cache invalidation is not instantaneous and follows eventual consistency model
+- **API token management**: Some platforms require API tokens for programmatic invalidation, adding configuration complexity
+- **Platform fragmentation**: While we provide unified API, actual behavior may vary slightly between platforms based on their capabilities
+- **Tag header size limits**: CDNs have different limits for cache tag headers (Fastly: 16KB, Akamai: 8KB, etc.), which may limit how many tags can be used per route
+
+# Alternatives
+
+## Manual header management
+
+Users could continue setting headers manually using `Astro.response.headers.set()`. This provides maximum flexibility but is error-prone and platform-specific.
+
+## Build-time configuration only
+
+We could require all cache rules to be defined in `astro.config.ts` rather than per-route. This is simpler but less flexible and doesn't support dynamic cache policies based on data.
+
+## Middleware-based approach
+
+Implement caching entirely in middleware rather than as a first-class API. This gives users more control but requires more boilerplate and doesn't integrate well with live collections.
+
+# Adoption strategy
+
+## Rollout Plan
+
+1. **Experimental release**: Ship behind experimental flag, disabled by default. Cache configuration will be inside the `experimental` object:
+
+```ts
+export default defineConfig({
+  adapter: vercel(),
+  experimental: {
+    cache: {
+      driver: 'vercel', // or adapter default
+      routes: {
+        '/blog/**': { maxAge: 300 }
+      }
+    }
+  }
+});
+```
+
+2. **Adapter implementation**: Start with Netlify and Vercel adapters as they have the most mature caching APIs
+3. **Node adapter**: Implement in-memory caching for local development and simple deployments
+4. **Cloudflare adapter**: Add support once Worker cache API integration is stable
+5. **Stable release**: Move to stable once battle-tested on major platforms. Configuration moves from `experimental.cache` to `cache`.
+
+## Breaking Changes
+
+This is a **non-breaking addition**. The feature is disabled by default and users opt-in via experimental config. Existing code continues to work unchanged.
+
+## Migration Path
+
+Users currently setting cache headers manually can migrate incrementally:
+
+**Before:**
+
+```astro
+---
+Astro.response.headers.set('Cache-Control', 'public, max-age=300');
+Astro.response.headers.set('CDN-Cache-Control', 'public, max-age=300, stale-while-revalidate=3600');
+---
+```
+
+**After:**
+
+```astro
+---
+Astro.cache({ maxAge: 300, swr: 3600 });
+---
+```
+
+## Documentation Requirements
+
+- Guide on route caching concepts and when to use it
+- Per-adapter documentation on platform-specific behavior
+- Integration guide for live collections
+- Examples for common caching patterns
+- Troubleshooting guide for cache invalidation
+
+## Ecosystem Impact
+
+- **Live collections**: Natural integration point, making cache hints actually useful
+- **Adapters**: All SSR adapters should implement caching support
+- **Integrations**: CMS integrations can trigger cache invalidation on content changes
+- **Hosting platforms**: Platforms may need to document their specific caching behavior
+
+# Unresolved Questions
+
+- **Cache metadata API design**: Should we use an explicit `cacheHint` parameter, or use a hidden `Symbol` field on entry/collection objects? The symbol approach would allow `Astro.cache(entry)` instead of `Astro.cache(cacheHint)`, making the API cleaner while keeping cache metadata non-enumerable. Related: for collections, should cache metadata be on the collection result object, or on individual entries?
+- Should we support cache warming/preloading on deployment?
+- How should we handle cache invalidation across regions for globally distributed apps?
+- What metrics/observability should we provide for cache hit rates and invalidation?
+- Should tag matching support wildcards (e.g., `product:*`)?
+- Should we provide a CLI command for cache invalidation during development/testing?

--- a/proposals/0056-route-caching.md
+++ b/proposals/0056-route-caching.md
@@ -174,15 +174,10 @@ export default defineConfig({
     provider: memoryCache(),
   },
   routeRules: {
-    // Shortcut form (Nitro-style)
     "/": { swr: 60 },
     "/blog/[...path]": { maxAge: 300 },
     "/api/[...path]": { maxAge: 600 },
-
-    // Full form with nested cache
-    "/products/[...path]": {
-      cache: { maxAge: 300, swr: 3600, tags: ["products"] },
-    },
+    "/products/[...path]": { maxAge: 300, swr: 3600, tags: ["products"] },
   },
 });
 ```
@@ -1023,7 +1018,7 @@ export default defineConfig({
 
 You can declare cache rules for routes in your config using `routeRules`. These act as defaults that can be overridden by `Astro.cache.set()` calls within routes. The syntax is inspired by Nitro's route rules. It is deliberately a top-level config option rather than nested under `cache` to allow for future expansion of route-level options beyond caching, such as prerendering, headers and redirects.
 
-Route rules support shortcuts where cache options can be specified directly at the rule level, or nested under a `cache` key for the full form:
+Cache options are specified directly at the rule level:
 
 **Basic route patterns:**
 
@@ -1032,15 +1027,10 @@ Route rules support shortcuts where cache options can be specified directly at t
 export default defineConfig({
   adapter: vercel(),
   routeRules: {
-    // Shortcut form (Nitro-style)
     "/": { swr: 60 },
     "/blog/**": { maxAge: 300 },
     "/api/[...path]": { maxAge: 600 },
-
-    // Full form with nested cache
-    "/products/[...path]": {
-      cache: { maxAge: 300, swr: 3600, tags: ["products"] },
-    },
+    "/products/[...path]": { maxAge: 300, swr: 3600, tags: ["products"] },
   },
 });
 ```
@@ -1320,7 +1310,7 @@ export default defineConfig({
     },
     routeRules: {
       "/blog/**": { maxAge: 300 },
-      "/products/*": { cache: { maxAge: 600, tags: ["products"] } },
+      "/products/*": { maxAge: 600, tags: ["products"] },
     },
   },
 });

--- a/proposals/0056-route-caching.md
+++ b/proposals/0056-route-caching.md
@@ -723,9 +723,16 @@ lastModified → Last-Modified: Thu, 15 Jan 2025 00:00:00 GMT
 
 Note: Akamai supports the standardized `CDN-Cache-Control` header (RFC 9213) for Targeted Cache Control. Individual tags limited to 128 characters, total header limited to 8192 bytes. Tags are case-sensitive.
 
-**Node Memory Provider:**
+**Memory Provider:**
 
 Zero-dependency in-memory LRU cache with stale-while-revalidate support. As a runtime provider, it reads the `CDN-Cache-Control` and `Cache-Tag` headers set by the default header generation to determine caching behavior. TTL is determined per-entry from the response's cache headers rather than a global default.
+
+The memory provider normalizes cache keys for better hit rates:
+
+- **Query parameter sorting**: Parameters are sorted alphabetically, so `/page?b=2&a=1` and `/page?a=1&b=2` resolve to the same cache entry (enabled by default, configurable via `query.sort`)
+- **Tracking parameter exclusion**: Common analytics parameters (`utm_*`, `fbclid`, `gclid`, etc.) are stripped from cache keys by default (configurable via `query.exclude`)
+- **Query parameter allowlisting**: Optionally include only specific parameters in the cache key, ignoring all others (via `query.include`, mutually exclusive with `exclude`)
+- **Vary header support**: When a response includes a `Vary` header, the provider creates separate cache entries keyed by the specified request header values. `Vary: Cookie` is ignored (too high cardinality) — future work will add config-level cookie-based vary for specific cookie keys.
 
 ### Invalidation Implementation
 
@@ -1126,6 +1133,29 @@ The Node adapter maintains a zero-dependency in-memory LRU cache (default max: 1
 - Per-entry TTL derived from response cache headers
 - Size limits to prevent memory issues
 - Exact-path invalidation only (no wildcard patterns)
+- Query parameter normalization (sorting, tracking param exclusion, allowlisting)
+- `Vary` header-aware cache keying (separate entries per request variant)
+
+**Cache key normalization:**
+
+Query parameters are sorted alphabetically by default so that parameter order does not affect the cache key. Common tracking and analytics parameters (`utm_*`, `fbclid`, `gclid`, `msclkid`, `_ga`, `_gl`, etc.) are excluded by default. Users can customize this behavior:
+
+```ts
+import { memoryCache } from "astro/config";
+
+memoryCache({
+  query: {
+    sort: true, // default: true
+    exclude: [], // default: common tracking params; set to [] to include all
+    // OR:
+    include: ["page", "sort"], // allowlist mode (mutually exclusive with exclude)
+  },
+});
+```
+
+**Vary header support:**
+
+When a response includes a `Vary` header (e.g. `Vary: Accept-Language`), the memory provider incorporates the specified request header values into the cache key, creating separate entries per variant. `Vary: Cookie` and `Vary: Set-Cookie` are ignored — `Cookie` has too-high cardinality for effective caching. Config-level cookie-based vary (for specific cookie keys like `theme` or `locale`) is planned as a future enhancement.
 
 **Important limitations:**
 
@@ -1217,7 +1247,7 @@ export default defineConfig({
 
 **Setup:** Single Node.js server, no CDN
 **Provider:** `memoryCache()` from `astro/config` (automatic default)
-**Configuration:** Optional tuning of cache size
+**Configuration:** Optional tuning of cache size and query parameter handling
 **Behavior:** In-memory LRU cache, lost on restart
 
 ```ts
@@ -1231,6 +1261,10 @@ export default defineConfig({
   cache: {
     provider: memoryCache({
       max: 1000,
+      query: {
+        // Sort params (default: true), exclude tracking params (default: common list)
+        // Use include for allowlist mode: include: ['page', 'sort']
+      },
     }),
   },
 });

--- a/proposals/0056-route-caching.md
+++ b/proposals/0056-route-caching.md
@@ -14,7 +14,7 @@
 
 - Start Date: 2025-10-15
 - Reference Issues: https://github.com/withastro/roadmap/discussions/1131, https://github.com/withastro/roadmap/discussions/181
-- Implementation PR: <!-- leave empty -->
+- Implementation PR: https://github.com/withastro/astro/pull/15579
 - Stage 2 Issue: https://github.com/withastro/roadmap/issues/1140
 - Stage 3 PR: https://github.com/withastro/roadmap/pull/1245
 


### PR DESCRIPTION
<!--
**Warning**
**This template is reserved for approved proposals and Astro maintainers only.**
You are probably looking to [**start a discussion**](https://github.com/withastro/roadmap/discussions/new)!

Community members who would like to propose an idea or feature should begin
by creating a GitHub Discussion. See the repo [`README.md`](https://github.com/withastro/roadmap#readme) for more info.
-->

# Summary

A platform-agnostic route caching API for Astro SSR pages that enables declarative cache control using web standards. 

# Examples

## Basic route caching

```astro
---
// src/pages/products/[id].astro
import { getEntry } from 'astro:content';
const product = await getEntry('products', Astro.params.id);
Astro.cache.set({
  lastModified: product.updatedAt,
  maxAge: 300,  // Cache for 5 minutes
  swr: 3600,    // Stale-while-revalidate for 1 hour
  tags: ['products', `product:${product.id}`]
});
---
<h1>{product.data.name}</h1>
<p>{product.data.description}</p>
```

## Automatic dependency tracking

```ts
// src/pages/api/revalidate.ts
import { getLiveEntry } from "astro:content";

export const POST: APIRoute = async ({ cache, request }) => {
  const { id } = await request.json();
  const { entry } = await getLiveEntry("products", id);

  // Invalidate all pages that depend on this entry
  cache.invalidate(entry);

  return Response.json({ ok: true });
};
```


# Links
- [Rendered RFC](https://github.com/withastro/roadmap/blob/feat/route-caching/proposals/0056-route-caching.md)
- [Stage 2 Proposal](https://github.com/withastro/roadmap/issues/1140)
- [Stage 1 Proposal](https://github.com/withastro/roadmap/discussions/1131)